### PR TITLE
Fix respondent detail navigation and add editing

### DIFF
--- a/app/data-import/page.tsx
+++ b/app/data-import/page.tsx
@@ -377,7 +377,11 @@ export default function DataImportPage() {
                       <Button variant="outline" size="sm" onClick={() => router.push(`/followup/new/${respondent.id}`)}>
                         Start Follow-up
                       </Button>
-                      <Button variant="ghost" size="sm" onClick={() => router.push(`/respondents?id=${respondent.id}`)}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => router.push(`/respondents/${respondent.id}`)}
+                      >
                         View Details
                       </Button>
                     </div>

--- a/app/respondents/[id]/page.tsx
+++ b/app/respondents/[id]/page.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { createClient } from "@/lib/supabase/client"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ArrowLeft } from "lucide-react"
+
+interface Respondent {
+  id: string
+  district: string
+  sub_county: string
+  parish: string
+  age: string
+  gender: string
+  education_level: string
+  occupation: string
+  industry_involvement: string
+  value_chain_role: string
+  respondent_name: string
+  group_name: string
+  created_at: string
+}
+
+export default function RespondentDetailPage({ params }: { params: { id: string } }) {
+  const router = useRouter()
+  const { id } = params
+
+  const [respondent, setRespondent] = useState<Respondent | null>(null)
+  const [formData, setFormData] = useState<Respondent | null>(null)
+  const [isEditing, setIsEditing] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchRespondent = async () => {
+      try {
+        const supabase = createClient()
+        const { data, error } = await supabase
+          .from("survey_respondents")
+          .select(
+            `id, district, sub_county, parish, age, gender, education_level,
+            occupation, industry_involvement, value_chain_role, respondent_name,
+            group_name, created_at`
+          )
+          .eq("id", id)
+          .single()
+
+        if (error) throw error
+        setRespondent(data)
+        setFormData(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred")
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchRespondent()
+  }, [id])
+
+  const handleChange = (field: keyof Respondent, value: string) => {
+    setFormData((prev) => (prev ? { ...prev, [field]: value } : prev))
+  }
+
+  const handleSave = async () => {
+    if (!formData) return
+    const supabase = createClient()
+    const { error } = await supabase
+      .from("survey_respondents")
+      .update({
+        district: formData.district,
+        sub_county: formData.sub_county,
+        parish: formData.parish,
+        age: formData.age,
+        gender: formData.gender,
+        education_level: formData.education_level,
+        occupation: formData.occupation,
+        industry_involvement: formData.industry_involvement,
+        value_chain_role: formData.value_chain_role,
+        respondent_name: formData.respondent_name,
+        group_name: formData.group_name,
+      })
+      .eq("id", id)
+
+    if (error) {
+      setError(error.message)
+    } else {
+      setRespondent(formData)
+      setIsEditing(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        Loading respondent...
+      </div>
+    )
+  }
+
+  if (error || !respondent) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-red-600">
+        {error || "Respondent not found"}
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center h-16">
+            <Button
+              variant="ghost"
+              className="flex items-center"
+              onClick={() => router.push("/respondents")}
+            >
+              <ArrowLeft className="h-5 w-5 mr-2" />
+              Back to Respondents
+            </Button>
+            <h1 className="ml-4 text-xl font-semibold">Respondent Details</h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>{respondent.respondent_name || "Unnamed Respondent"}</CardTitle>
+            <CardDescription>View and edit respondent information</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isEditing && formData ? (
+              <div className="space-y-4">
+                <Input
+                  value={formData.respondent_name || ""}
+                  onChange={(e) => handleChange("respondent_name", e.target.value)}
+                  placeholder="Name"
+                />
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <Input
+                    value={formData.district || ""}
+                    onChange={(e) => handleChange("district", e.target.value)}
+                    placeholder="District"
+                  />
+                  <Input
+                    value={formData.sub_county || ""}
+                    onChange={(e) => handleChange("sub_county", e.target.value)}
+                    placeholder="Sub-county"
+                  />
+                  <Input
+                    value={formData.parish || ""}
+                    onChange={(e) => handleChange("parish", e.target.value)}
+                    placeholder="Parish"
+                  />
+                  <Input
+                    value={formData.age || ""}
+                    onChange={(e) => handleChange("age", e.target.value)}
+                    placeholder="Age"
+                  />
+                  <Input
+                    value={formData.gender || ""}
+                    onChange={(e) => handleChange("gender", e.target.value)}
+                    placeholder="Gender"
+                  />
+                  <Input
+                    value={formData.education_level || ""}
+                    onChange={(e) => handleChange("education_level", e.target.value)}
+                    placeholder="Education Level"
+                  />
+                  <Input
+                    value={formData.occupation || ""}
+                    onChange={(e) => handleChange("occupation", e.target.value)}
+                    placeholder="Occupation"
+                  />
+                  <Input
+                    value={formData.industry_involvement || ""}
+                    onChange={(e) => handleChange("industry_involvement", e.target.value)}
+                    placeholder="Industry"
+                  />
+                  <Input
+                    value={formData.value_chain_role || ""}
+                    onChange={(e) => handleChange("value_chain_role", e.target.value)}
+                    placeholder="Role"
+                  />
+                  <Input
+                    value={formData.group_name || ""}
+                    onChange={(e) => handleChange("group_name", e.target.value)}
+                    placeholder="Group"
+                  />
+                </div>
+                <div className="flex space-x-2">
+                  <Button onClick={handleSave}>Save</Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setIsEditing(false)
+                      setFormData(respondent)
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2 text-sm">
+                <div>
+                  <span className="font-medium">District:</span> {respondent.district}
+                </div>
+                <div>
+                  <span className="font-medium">Sub-county:</span> {respondent.sub_county}
+                </div>
+                <div>
+                  <span className="font-medium">Parish:</span> {respondent.parish}
+                </div>
+                <div>
+                  <span className="font-medium">Age:</span> {respondent.age}
+                </div>
+                <div>
+                  <span className="font-medium">Gender:</span> {respondent.gender}
+                </div>
+                <div>
+                  <span className="font-medium">Education:</span> {respondent.education_level}
+                </div>
+                <div>
+                  <span className="font-medium">Occupation:</span> {respondent.occupation}
+                </div>
+                <div>
+                  <span className="font-medium">Industry:</span> {respondent.industry_involvement}
+                </div>
+                <div>
+                  <span className="font-medium">Role:</span> {respondent.value_chain_role}
+                </div>
+                <div>
+                  <span className="font-medium">Group:</span> {respondent.group_name}
+                </div>
+                <div>
+                  <span className="font-medium">Date Added:</span> {new Date(respondent.created_at).toLocaleDateString()}
+                </div>
+                <Button className="mt-4" variant="outline" onClick={() => setIsEditing(true)}>
+                  Edit
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  )
+}
+

--- a/app/respondents/page.tsx
+++ b/app/respondents/page.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Badge } from "@/components/ui/badge"
 import { ArrowLeft, Search, Download, Edit, Trash2 } from "lucide-react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 
 interface Respondent {
   id: string
@@ -33,6 +34,7 @@ export default function RespondentsPage() {
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [filterDistrict, setFilterDistrict] = useState("")
+  const router = useRouter()
 
   useEffect(() => {
     fetchRespondents()
@@ -275,7 +277,11 @@ export default function RespondentsPage() {
                       <TableCell className="text-sm">{new Date(respondent.created_at).toLocaleDateString()}</TableCell>
                       <TableCell>
                         <div className="flex items-center space-x-2">
-                          <Button size="sm" variant="outline">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => router.push(`/respondents/${respondent.id}`)}
+                          >
                             <Edit className="h-4 w-4" />
                           </Button>
                           <Button size="sm" variant="outline" onClick={() => handleDelete(respondent.id)}>


### PR DESCRIPTION
## Summary
- Add dedicated respondent details page with editable form backed by Supabase
- Wire Data Import and Respondents pages to navigate to detail page for view/edit actions

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68af5fbe21b88333975f5a85ca45cd3c