### PR TITLE
feat: add responsive layout and table pagination

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import Link from "next/link"
-import { BarChart3, Users, FileText, TrendingUp, UserPlus } from "lucide-react"
 import DataImportPage from "../data-import/page"
 
 export default function DashboardPage() {
@@ -31,48 +29,26 @@ export default function DashboardPage() {
   }, [router])
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
-      <aside className="w-64 bg-white border-r p-6 space-y-4">
-        <h2 className="text-xl font-bold">Menu</h2>
-        <nav className="space-y-2">
-          <Link href="/analytics" className="flex items-center space-x-2 text-gray-700 hover:text-blue-600">
-            <BarChart3 className="h-4 w-4" /> <span>Analytics</span>
-          </Link>
-          <Link href="/followup" className="flex items-center space-x-2 text-gray-700 hover:text-blue-600">
-            <UserPlus className="h-4 w-4" /> <span>Follow-up</span>
-          </Link>
-          <Link href="/respondents" className="flex items-center space-x-2 text-gray-700 hover:text-blue-600">
-            <Users className="h-4 w-4" /> <span>Respondents</span>
-          </Link>
-          <Link href="/reports" className="flex items-center space-x-2 text-gray-700 hover:text-blue-600">
-            <FileText className="h-4 w-4" /> <span>Reports</span>
-          </Link>
-          <Link href="/comparison" className="flex items-center space-x-2 text-gray-700 hover:text-blue-600">
-            <TrendingUp className="h-4 w-4" /> <span>Comparison</span>
-          </Link>
-        </nav>
-      </aside>
-      <div className="flex-1 flex flex-col">
-        <header className="bg-white shadow-sm border-b">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center h-16">
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">CWEN WGCT Analytics</h1>
-                <p className="text-sm text-gray-600">Community Women's Enterprise Network</p>
-              </div>
-              <div className="flex items-center space-x-4">
-                <span className="text-sm text-gray-700">Welcome, {profile?.full_name || userEmail}</span>
-                <form action="/auth/signout" method="post">
-                  <Button variant="outline" size="sm">Sign Out</Button>
-                </form>
-              </div>
+    <div className="flex flex-col">
+      <header className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">CWEN WGCT Analytics</h1>
+              <p className="text-sm text-gray-600">Community Women's Enterprise Network</p>
+            </div>
+            <div className="flex items-center space-x-4">
+              <span className="text-sm text-gray-700">Welcome, {profile?.full_name || userEmail}</span>
+              <form action="/auth/signout" method="post">
+                <Button variant="outline" size="sm">Sign Out</Button>
+              </form>
             </div>
           </div>
-        </header>
-        <main className="flex-1 overflow-y-auto">
-          <DataImportPage embedded />
-        </main>
-      </div>
+        </div>
+      </header>
+      <main className="flex-1 overflow-y-auto">
+        <DataImportPage embedded />
+      </main>
     </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
+import { Sidebar } from '@/components/sidebar'
+import { ThemeProvider } from '@/components/theme-provider'
 
 export const metadata: Metadata = {
   title: 'CWEN Tool',
@@ -17,7 +19,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
-        {children}
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <div className="flex min-h-screen bg-gray-50">
+            <Sidebar />
+            <main className="flex-1 md:ml-64 p-4 md:p-6 overflow-x-hidden">
+              {children}
+            </main>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/app/respondents/page.tsx
+++ b/app/respondents/page.tsx
@@ -7,7 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
-import { ArrowLeft, Search, Download, Edit, Trash2 } from "lucide-react"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ArrowLeft, Search, Download, Edit, Trash2, ChevronLeft, ChevronRight } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
@@ -34,6 +35,7 @@ export default function RespondentsPage() {
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [filterDistrict, setFilterDistrict] = useState("")
+  const [page, setPage] = useState(1)
   const router = useRouter()
 
   useEffect(() => {
@@ -84,6 +86,7 @@ export default function RespondentsPage() {
     }
 
     setFilteredRespondents(filtered)
+    setPage(1)
   }
 
   const handleDelete = async (id: string) => {
@@ -144,6 +147,12 @@ export default function RespondentsPage() {
   }
 
   const uniqueDistricts = [...new Set(respondents.map((r) => r.district).filter(Boolean))]
+  const itemsPerPage = 15
+  const pageCount = Math.ceil(filteredRespondents.length / itemsPerPage)
+  const paginatedRespondents = filteredRespondents.slice(
+    (page - 1) * itemsPerPage,
+    page * itemsPerPage,
+  )
 
   if (isLoading) {
     return (
@@ -207,22 +216,23 @@ export default function RespondentsPage() {
                 </div>
               </div>
               <div className="w-full md:w-48">
-                <select
-                  value={filterDistrict}
-                  onChange={(e) => setFilterDistrict(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="">All Districts</option>
-                  {uniqueDistricts.map((district) => (
-                    <option key={district} value={district}>
-                      {district}
-                    </option>
-                  ))}
-                </select>
+                <Select value={filterDistrict} onValueChange={setFilterDistrict}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="All Districts" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">All Districts</SelectItem>
+                    {uniqueDistricts.map((district) => (
+                      <SelectItem key={district} value={district}>
+                        {district}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
             <div className="mt-4 text-sm text-gray-600">
-              Showing {filteredRespondents.length} of {respondents.length} respondents
+              Showing {paginatedRespondents.length} of {filteredRespondents.length} respondents
             </div>
           </CardContent>
         </Card>
@@ -248,7 +258,7 @@ export default function RespondentsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredRespondents.map((respondent) => (
+                  {paginatedRespondents.map((respondent) => (
                     <TableRow key={respondent.id}>
                       <TableCell className="font-medium">{respondent.respondent_name || "N/A"}</TableCell>
                       <TableCell>
@@ -297,6 +307,29 @@ export default function RespondentsPage() {
             {filteredRespondents.length === 0 && (
               <div className="text-center py-8 text-gray-500">
                 {searchTerm || filterDistrict ? "No respondents match your filters." : "No respondents found."}
+              </div>
+            )}
+            {pageCount > 1 && (
+              <div className="flex justify-end items-center gap-2 mt-4">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page === 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <span className="text-sm">
+                  Page {page} of {pageCount}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page === pageCount}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
               </div>
             )}
           </CardContent>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+import {
+  Home,
+  BarChart3,
+  Users,
+  FileText,
+  Database,
+  Menu,
+  X,
+} from "lucide-react"
+
+const navItems = [
+  { href: "/dashboard", label: "Dashboard", icon: Home },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/respondents", label: "Respondents", icon: Users },
+  { href: "/reports", label: "Reports", icon: FileText },
+  { href: "/data-import", label: "Data Import", icon: Database },
+]
+
+export function Sidebar() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        className="fixed top-4 left-4 z-50 md:hidden p-2 text-gray-700 bg-white rounded-md shadow"
+        aria-label="Toggle Menu"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+      </button>
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-50 w-64 bg-gray-900 text-gray-100 transform transition-transform md:translate-x-0 md:static md:inset-auto",
+          open ? "translate-x-0" : "-translate-x-full",
+        )}
+      >
+        <div className="p-6 text-2xl font-bold">CWEN Tool</div>
+        <nav className="px-4 space-y-1">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-800"
+              onClick={() => setOpen(false)}
+            >
+              <item.icon className="h-5 w-5" />
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add global responsive sidebar with consistent navigation icons
- integrate theme provider and layout wrappers
- paginate respondents table with styled district filter
- streamline dashboard to use shared layout

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)
- `pnpm build` (fails: Can't resolve 'jspdf', 'html2canvas')

------
https://chatgpt.com/codex/tasks/task_e_68af688bcfcc833388a720db05c9c0ec