### PR TITLE
Improve UI styling with responsive sidebar and pagination

### DIFF
--- a/app/followup/history/page.tsx
+++ b/app/followup/history/page.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Badge } from "@/components/ui/badge"
 import { ArrowLeft, Search, Calendar, User, Eye } from "lucide-react"
 import Link from "next/link"
+import { Pagination } from "@/components/ui/pagination"
 
 interface FollowupSurvey {
   id: string
@@ -34,6 +35,7 @@ export default function FollowupHistoryPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
+  const [page, setPage] = useState(1)
 
   useEffect(() => {
     fetchFollowups()
@@ -78,6 +80,7 @@ export default function FollowupHistoryPage() {
     }
 
     setFilteredFollowups(filtered)
+    setPage(1)
   }
 
   if (isLoading) {
@@ -90,6 +93,13 @@ export default function FollowupHistoryPage() {
       </div>
     )
   }
+
+  const itemsPerPage = 15
+  const pageCount = Math.ceil(filteredFollowups.length / itemsPerPage)
+  const paginatedFollowups = filteredFollowups.slice(
+    (page - 1) * itemsPerPage,
+    page * itemsPerPage,
+  )
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -130,7 +140,7 @@ export default function FollowupHistoryPage() {
               />
             </div>
             <div className="mt-4 text-sm text-gray-600">
-              Showing {filteredFollowups.length} of {followups.length} follow-up surveys
+              Showing {paginatedFollowups.length} of {filteredFollowups.length} follow-up surveys
             </div>
           </CardContent>
         </Card>
@@ -156,7 +166,7 @@ export default function FollowupHistoryPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredFollowups.map((followup) => (
+                  {paginatedFollowups.map((followup) => (
                     <TableRow key={followup.id}>
                       <TableCell>
                         <div className="flex items-center space-x-3">
@@ -220,6 +230,9 @@ export default function FollowupHistoryPage() {
               <div className="text-center py-8 text-gray-500">
                 {searchTerm ? "No follow-up surveys match your search." : "No follow-up surveys found."}
               </div>
+            )}
+            {pageCount > 1 && (
+              <Pagination page={page} pageCount={pageCount} onPageChange={setPage} />
             )}
           </CardContent>
         </Card>

--- a/app/respondents/page.tsx
+++ b/app/respondents/page.tsx
@@ -8,9 +8,10 @@ import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ArrowLeft, Search, Download, Edit, Trash2, ChevronLeft, ChevronRight } from "lucide-react"
+import { ArrowLeft, Search, Download, Edit, Trash2 } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { Pagination } from "@/components/ui/pagination"
 
 interface Respondent {
   id: string
@@ -310,27 +311,7 @@ export default function RespondentsPage() {
               </div>
             )}
             {pageCount > 1 && (
-              <div className="flex justify-end items-center gap-2 mt-4">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page === 1}
-                  onClick={() => setPage((p) => p - 1)}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-                <span className="text-sm">
-                  Page {page} of {pageCount}
-                </span>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page === pageCount}
-                  onClick={() => setPage((p) => p + 1)}
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </div>
+              <Pagination page={page} pageCount={pageCount} onPageChange={setPage} />
             )}
           </CardContent>
         </Card>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { useState } from "react"
+import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import {
   Home,
@@ -23,6 +24,7 @@ const navItems = [
 
 export function Sidebar() {
   const [open, setOpen] = useState(false)
+  const pathname = usePathname()
   return (
     <>
       <button
@@ -34,23 +36,31 @@ export function Sidebar() {
       </button>
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-50 w-64 bg-gray-900 text-gray-100 transform transition-transform md:translate-x-0 md:static md:inset-auto",
+          "fixed inset-y-0 left-0 z-50 w-64 bg-gradient-to-b from-slate-900 to-indigo-900 text-gray-100 shadow-lg transform transition-transform md:translate-x-0 md:static md:inset-auto",
           open ? "translate-x-0" : "-translate-x-full",
         )}
       >
-        <div className="p-6 text-2xl font-bold">CWEN Tool</div>
-        <nav className="px-4 space-y-1">
-          {navItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-800"
-              onClick={() => setOpen(false)}
-            >
-              <item.icon className="h-5 w-5" />
-              {item.label}
-            </Link>
-          ))}
+        <div className="p-6 text-2xl font-bold tracking-tight">CWEN Tool</div>
+        <nav className="px-4 space-y-1 overflow-y-auto">
+          {navItems.map((item) => {
+            const active = pathname.startsWith(item.href)
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-indigo-700 text-white"
+                    : "text-gray-200 hover:bg-indigo-800 hover:text-white",
+                )}
+                onClick={() => setOpen(false)}
+              >
+                <item.icon className="h-5 w-5" />
+                {item.label}
+              </Link>
+            )
+          })}
         </nav>
       </aside>
       {open && (

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+interface PaginationProps {
+  page: number
+  pageCount: number
+  onPageChange: (page: number) => void
+}
+
+export function Pagination({ page, pageCount, onPageChange }: PaginationProps) {
+  if (pageCount <= 1) return null
+  return (
+    <div className="flex justify-end items-center gap-2 mt-4">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={page === 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <span className="text-sm">
+        Page {page} of {pageCount}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={page === pageCount}
+        onClick={() => onPageChange(page + 1)}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -8,7 +8,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className="relative w-full overflow-x-auto rounded-lg border bg-card shadow-sm"
     >
       <table
         data-slot="table"
@@ -23,7 +23,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+      className={cn("bg-muted [&_tr]:border-b", className)}
       {...props}
     />
   )
@@ -57,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "border-b transition-colors even:bg-muted/50 hover:bg-muted/80 data-[state=selected]:bg-muted",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Refresh sidebar with gradient background, active link highlight, and smoother mobile toggle
- Enhance table styling and add reusable pagination component
- Integrate pagination for respondents and follow-up history tables

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e50c1a48333a6ffa043189807a2