### PR TITLE
Align main content with sidebar

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -248,7 +248,7 @@ export default function AnalyticsPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <Link href="/dashboard" className="flex items-center text-gray-600 hover:text-gray-900">
@@ -270,7 +270,7 @@ export default function AnalyticsPage() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         {/* Filters */}
         <Card className="mb-8">
           <CardHeader>

--- a/app/comparison/details/[id]/page.tsx
+++ b/app/comparison/details/[id]/page.tsx
@@ -139,7 +139,7 @@ export default function ComparisonDetailsPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center h-16">
             <Link href="/comparison" className="flex items-center text-gray-600 hover:text-gray-900">
               <ArrowLeft className="h-5 w-5 mr-2" />
@@ -153,7 +153,7 @@ export default function ComparisonDetailsPage() {
         </div>
       </header>
 
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
         {/* Respondent Overview */}
         <Card className="mb-8">
           <CardHeader>

--- a/app/comparison/page.tsx
+++ b/app/comparison/page.tsx
@@ -208,7 +208,7 @@ export default function ComparisonPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <Link href="/dashboard" className="flex items-center text-gray-600 hover:text-gray-900">
@@ -235,7 +235,7 @@ export default function ComparisonPage() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         {error && <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">{error}</div>}
 
         {/* Key Metrics */}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -31,7 +31,7 @@ export default function DashboardPage() {
   return (
     <div className="flex flex-col">
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div>
               <h1 className="text-2xl font-bold text-gray-900">CWEN WGCT Analytics</h1>

--- a/app/data-import/page.tsx
+++ b/app/data-import/page.tsx
@@ -160,7 +160,7 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
     <div className={embedded ? "" : "min-h-screen bg-gray-50"}>
       {!embedded && (
         <header className="bg-white shadow-sm border-b">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between h-16">
               <div className="flex items-center">
                 <Link href="/dashboard" className="flex items-center text-gray-600 hover:text-gray-900">
@@ -183,7 +183,7 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
         </header>
       )}
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         {/* Status Messages */}
         {error && <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">{error}</div>}
 

--- a/app/followup/history/page.tsx
+++ b/app/followup/history/page.tsx
@@ -105,7 +105,7 @@ export default function FollowupHistoryPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <Link href="/followup" className="flex items-center text-gray-600 hover:text-gray-900">
@@ -121,7 +121,7 @@ export default function FollowupHistoryPage() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         {error && <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">{error}</div>}
 
         {/* Search */}

--- a/app/followup/new/[id]/page.tsx
+++ b/app/followup/new/[id]/page.tsx
@@ -175,7 +175,7 @@ export default function NewFollowupPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center h-16">
             <Link href="/followup" className="flex items-center text-gray-600 hover:text-gray-900">
               <ArrowLeft className="h-5 w-5 mr-2" />
@@ -189,7 +189,7 @@ export default function NewFollowupPage() {
         </div>
       </header>
 
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-4xl px-4 sm:px-6 lg:px-8 py-8">
         {/* Status Messages */}
         {error && <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">{error}</div>}
         {success && (

--- a/app/followup/page.tsx
+++ b/app/followup/page.tsx
@@ -112,7 +112,7 @@ export default function FollowupPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <Link href="/dashboard" className="flex items-center text-gray-600 hover:text-gray-900">
@@ -136,7 +136,7 @@ export default function FollowupPage() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         {error && <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">{error}</div>}
 
         {/* Search */}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <div className="flex min-h-screen bg-gray-50">
             <Sidebar />
-            <main className="flex-1 md:ml-64 p-4 md:p-6 overflow-x-hidden">
+            <main className="flex-1 p-4 md:p-6 overflow-x-hidden">
               {children}
             </main>
           </div>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -63,7 +63,7 @@ export default function ReportsPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center h-16">
             <Link href="/dashboard" className="flex items-center text-gray-600 hover:text-gray-900">
               <ArrowLeft className="h-5 w-5 mr-2" />
@@ -77,7 +77,7 @@ export default function ReportsPage() {
         </div>
       </header>
 
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-4xl px-4 sm:px-6 lg:px-8 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Report Configuration */}
           <div className="lg:col-span-2 space-y-6">

--- a/app/respondents/[id]/page.tsx
+++ b/app/respondents/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function RespondentDetailPage({ params }: { params: { id: string 
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center h-16">
             <Button
               variant="ghost"
@@ -127,7 +127,7 @@ export default function RespondentDetailPage({ params }: { params: { id: string 
         </div>
       </header>
 
-      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-3xl px-4 sm:px-6 lg:px-8 py-8">
         <Card>
           <CardHeader>
             <CardTitle>{respondent.respondent_name || "Unnamed Respondent"}</CardTitle>

--- a/app/respondents/page.tsx
+++ b/app/respondents/page.tsx
@@ -170,7 +170,7 @@ export default function RespondentsPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <Link href="/dashboard" className="flex items-center text-gray-600 hover:text-gray-900">
@@ -195,7 +195,7 @@ export default function RespondentsPage() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         {error && <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">{error}</div>}
 
         {/* Filters */}


### PR DESCRIPTION
## Summary
- Remove unnecessary left margin from main layout so content sits flush next to the sidebar
- Drop `mx-auto` centering on page containers so sections align with sidebar

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Module not found: Can't resolve 'jspdf', 'html2canvas')*

------
https://chatgpt.com/codex/tasks/task_e_68af719f4f2083338c51afc444f027e4