### PR TITLE
Use relative login path on signout

### DIFF
--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
 import { NextResponse } from "next/server"
 
-export async function POST() {
+export async function POST(request: Request) {
   const supabase = await createClient()
 
   const { error } = await supabase.auth.signOut()
@@ -10,5 +10,5 @@ export async function POST() {
     return NextResponse.json({ error: error.message }, { status: 400 })
   }
 
-  return NextResponse.redirect(new URL("/auth/login", process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"))
+  return NextResponse.redirect(new URL("/auth/login", request.url))
 }


### PR DESCRIPTION
## Summary
- redirect sign-out to `/auth/login` relative to the current request

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b0181daa008333bedb9fbcb1895f32