### PR TITLE
Track coffee and tea farmer counts

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -11,6 +11,8 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 
 interface AnalyticsData {
   totalRespondents: number
+  coffeeFarmers: number
+  teaFarmers: number
   demographics: {
     gender: { name: string; value: number }[]
     education: { name: string; value: number }[]
@@ -87,6 +89,18 @@ export default function AnalyticsPage() {
 
   const processAnalyticsData = (respondents: any[]): AnalyticsData => {
     const totalRespondents = respondents.length
+
+    const coffeeFarmers = respondents.filter(
+      (r) =>
+        r.value_chain_role?.toLowerCase().includes("farmer") &&
+        r.industry_involvement?.toLowerCase().includes("coffee"),
+    ).length
+
+    const teaFarmers = respondents.filter(
+      (r) =>
+        r.value_chain_role?.toLowerCase().includes("farmer") &&
+        r.industry_involvement?.toLowerCase().includes("tea"),
+    ).length
 
     // Demographics
     const genderCounts = respondents.reduce((acc, r) => {
@@ -185,6 +199,8 @@ export default function AnalyticsPage() {
 
     return {
       totalRespondents,
+      coffeeFarmers,
+      teaFarmers,
       demographics: {
         gender: toChartData(genderCounts),
         education: toChartData(educationCounts),
@@ -214,6 +230,8 @@ export default function AnalyticsPage() {
     const csvContent = [
       ["Metric", "Category", "Value"],
       ["Total Respondents", "", data.totalRespondents.toString()],
+      ["Coffee Farmers", "", data.coffeeFarmers.toString()],
+      ["Tea Farmers", "", data.teaFarmers.toString()],
       ...data.demographics.gender.map((item) => ["Gender", item.name, item.value.toString()]),
       ...data.demographics.education.map((item) => ["Education", item.name, item.value.toString()]),
       ...data.business.occupation.map((item) => ["Occupation", item.name, item.value.toString()]),
@@ -331,7 +349,7 @@ export default function AnalyticsPage() {
         </Card>
 
         {/* Key Metrics */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-6 mb-8">
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Total Respondents</CardTitle>
@@ -358,10 +376,18 @@ export default function AnalyticsPage() {
               <Briefcase className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">
-                {data?.business.industry.find((i) => i.name === "Coffee")?.value || 0}
-              </div>
+              <div className="text-2xl font-bold">{data?.coffeeFarmers || 0}</div>
               <p className="text-xs text-muted-foreground">Coffee value chain</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Tea Farmers</CardTitle>
+              <Briefcase className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{data?.teaFarmers || 0}</div>
+              <p className="text-xs text-muted-foreground">Tea value chain</p>
             </CardContent>
           </Card>
           <Card>

--- a/app/data-import/page.tsx
+++ b/app/data-import/page.tsx
@@ -101,6 +101,18 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
 
   const uniqueGenders = [...new Set(respondents.map((r) => r.gender).filter(Boolean))].sort()
 
+  const coffeeFarmersCount = respondents.filter(
+    (r) =>
+      r.value_chain_role?.toLowerCase().includes("farmer") &&
+      r.industry_involvement?.toLowerCase().includes("coffee"),
+  ).length
+
+  const teaFarmersCount = respondents.filter(
+    (r) =>
+      r.value_chain_role?.toLowerCase().includes("farmer") &&
+      r.industry_involvement?.toLowerCase().includes("tea"),
+  ).length
+
   const exportData = () => {
     const csvContent = [
       // CSV headers
@@ -238,9 +250,7 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
                 </div>
                 <div className="ml-4">
                   <p className="text-sm font-medium text-gray-600">Coffee Farmers</p>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {respondents.filter((r) => r.industry_involvement === "Coffee").length}
-                  </p>
+                  <p className="text-2xl font-bold text-gray-900">{coffeeFarmersCount}</p>
                 </div>
               </div>
             </CardContent>
@@ -254,9 +264,7 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
                 </div>
                 <div className="ml-4">
                   <p className="text-sm font-medium text-gray-600">Tea Farmers</p>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {respondents.filter((r) => r.industry_involvement === "Tea").length}
-                  </p>
+                  <p className="text-2xl font-bold text-gray-900">{teaFarmersCount}</p>
                 </div>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- count coffee and tea farmers by filtering survey responses for farmer value chain roles and coffee/tea industry involvement
- expose coffee and tea farmer totals on the analytics dashboard metrics and export
- show coffee and tea farmer totals on the data import dashboard cards

## Testing
- `pnpm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b91b30ff8c8333b6e23e94b003142b