### PR TITLE
Allow custom entries for passions and industries

### DIFF
--- a/app/followup/new/[id]/page.tsx
+++ b/app/followup/new/[id]/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { ArrowLeft } from "lucide-react"
@@ -123,6 +124,7 @@ export default function NewFollowupPage() {
   const [incomeChange, setIncomeChange] = useState("")
   const [groupEarnings, setGroupEarnings] = useState("")
   const [passions, setPassions] = useState<string[]>([])
+  const [otherPassion, setOtherPassion] = useState("")
   const [lacking, setLacking] = useState<string[]>([])
   const [gScores, setGScores] = useState({ g1: "", g2: "", g3: "", g4: "", g5: "", g6: "" })
   const [g7, setG7] = useState("")
@@ -167,7 +169,9 @@ export default function NewFollowupPage() {
       group_progress: groupProgress ? parseInt(groupProgress) : null,
       income_change: incomeChange ? parseInt(incomeChange) : null,
       group_earnings: groupEarnings ? parseInt(groupEarnings) : null,
-      low_interest_activities: passions,
+      low_interest_activities: passions
+        .map((p) => (p === "Other" ? otherPassion : p))
+        .filter(Boolean),
       lacking_support: lacking,
       g1: gScores.g1 ? parseInt(gScores.g1) : null,
       g2: gScores.g2 ? parseInt(gScores.g2) : null,
@@ -316,17 +320,37 @@ export default function NewFollowupPage() {
           {
             question: "In which activities does your group have low passion / low interest?",
             auto: false,
-            render: () => (
-              <div className="space-y-2">
-                {passionOptions.map((p) => (
-                  <label key={p} className="flex items-center space-x-2">
-                    <Checkbox checked={passions.includes(p)} onCheckedChange={() => toggle(passions, p, setPassions)} />
+          render: () => (
+            <div className="space-y-2">
+              {passionOptions.map((p) => (
+                <label key={p} className="flex items-center space-x-2">
+                  <Checkbox
+                    checked={passions.includes(p)}
+                    onCheckedChange={(checked) => {
+                      toggle(passions, p, setPassions)
+                      if (!checked && p === "Other") setOtherPassion("")
+                    }}
+                  />
+                  {p === "Other" ? (
+                    <>
+                      <span>Other:</span>
+                      {passions.includes("Other") && (
+                        <Input
+                          value={otherPassion}
+                          onChange={(e) => setOtherPassion(e.target.value)}
+                          placeholder="Specify"
+                          className="h-8"
+                        />
+                      )}
+                    </>
+                  ) : (
                     <span>{p}</span>
-                  </label>
-                ))}
-              </div>
-            ),
-          },
+                  )}
+                </label>
+              ))}
+            </div>
+          ),
+        },
           {
             question: "For the activities you are pursuing, where do you feel you’re still lacking?",
             auto: false,

--- a/app/respondents/new/page.tsx
+++ b/app/respondents/new/page.tsx
@@ -45,6 +45,7 @@ export default function NewRespondentPage() {
   })
   const [industries, setIndustries] = useState<Industry[]>([])
   const [selectedIndustries, setSelectedIndustries] = useState<string[]>([])
+  const [newIndustry, setNewIndustry] = useState("")
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -62,6 +63,23 @@ export default function NewRespondentPage() {
 
   const handleChange = (field: keyof Respondent, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const addIndustry = async () => {
+    const supabase = createClient()
+    const { data, error } = await supabase
+      .from("industries")
+      .insert({ name: newIndustry })
+      .select()
+      .single()
+    if (error) {
+      setError(error.message)
+      return
+    }
+    const added = data as Industry
+    setIndustries([...industries, added].sort((a, b) => a.name.localeCompare(b.name)))
+    setSelectedIndustries([...selectedIndustries, added.id])
+    setNewIndustry("")
   }
 
   const handleSave = async () => {
@@ -190,6 +208,14 @@ export default function NewRespondentPage() {
                         <span>{ind.name}</span>
                       </label>
                     ))}
+                    <div className="flex items-center space-x-2">
+                      <Input
+                        value={newIndustry}
+                        onChange={(e) => setNewIndustry(e.target.value)}
+                        placeholder="Other industry"
+                      />
+                      <Button onClick={addIndustry} disabled={!newIndustry.trim()}>Add</Button>
+                    </div>
                   </div>
                 </div>
                 <Input


### PR DESCRIPTION
## Summary
- Let follow-up survey responders specify a custom activity for low passion/interest via an "Other" text field
- Enable adding a new industry when creating respondents, immediately selecting the newly added item

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b943bbdfe083339192ec3a690b8b02