### PR TITLE
Improve Sankey chart layout and styling

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -51,6 +51,11 @@ export default function AnalyticsPage() {
   const [selectedGender, setSelectedGender] = useState<string>("all")
   const [districts, setDistricts] = useState<string[]>([])
 
+  const sankeyWidth = Math.max(
+    (data?.business.challengeSankey.nodes.length ?? 0) * 120,
+    600,
+  )
+
   useEffect(() => {
     fetchAnalyticsData()
   }, [selectedDistrict, selectedGender])
@@ -598,16 +603,22 @@ export default function AnalyticsPage() {
             <CardDescription>Links between groups and their challenges</CardDescription>
           </CardHeader>
           <CardContent>
-            <ResponsiveContainer width="100%" height={400}>
-              <Sankey
-                data={data?.business.challengeSankey}
-                nodeWidth={15}
-                nodePadding={40}
-                link={{ stroke: "#F59E0B" }}
-              >
-                <Tooltip />
-              </Sankey>
-            </ResponsiveContainer>
+            <div className="w-full overflow-auto">
+              <div style={{ width: sankeyWidth, height: 400 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <Sankey
+                    data={data?.business.challengeSankey}
+                    nodeWidth={15}
+                    nodePadding={40}
+                    node={{ fill: "#10B981", stroke: "#065F46", strokeWidth: 1 }}
+                    link={{ stroke: "#3B82F6", strokeOpacity: 0.5 }}
+                    margin={{ top: 20, bottom: 20 }}
+                  >
+                    <Tooltip />
+                  </Sankey>
+                </ResponsiveContainer>
+              </div>
+            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary
- Dynamically size the Top Business Challenges Sankey chart and wrap it in a scrollable container to avoid clipping
- Restyle Sankey nodes and links with higher-contrast colors for better readability

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd838f20c833393bec08a8aae9b56