### PR TITLE
Fix coffee and tea respondent counts and import utility

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -22,8 +22,8 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 
 interface AnalyticsData {
   totalRespondents: number
-  coffeeFarmers: number
-  teaFarmers: number
+  coffeeRespondents: number
+  teaRespondents: number
   demographics: {
     gender: { name: string; value: number }[]
     education: { name: string; value: number }[]
@@ -114,16 +114,12 @@ export default function AnalyticsPage() {
   const processAnalyticsData = (respondents: any[]): AnalyticsData => {
     const totalRespondents = respondents.length
 
-    const coffeeFarmers = respondents.filter(
-      (r) =>
-        r.value_chain_role?.toLowerCase().includes("farmer") &&
-        r.industry_involvement?.toLowerCase().includes("coffee"),
+    const coffeeRespondents = respondents.filter((r) =>
+      r.industry_involvement?.toLowerCase().includes("coffee"),
     ).length
 
-    const teaFarmers = respondents.filter(
-      (r) =>
-        r.value_chain_role?.toLowerCase().includes("farmer") &&
-        r.industry_involvement?.toLowerCase().includes("tea"),
+    const teaRespondents = respondents.filter((r) =>
+      r.industry_involvement?.toLowerCase().includes("tea"),
     ).length
 
     // Demographics
@@ -299,8 +295,8 @@ export default function AnalyticsPage() {
 
     return {
       totalRespondents,
-      coffeeFarmers,
-      teaFarmers,
+      coffeeRespondents,
+      teaRespondents,
       demographics: {
         gender: toChartData(genderCounts),
         education: toChartData(educationCounts),
@@ -336,8 +332,8 @@ export default function AnalyticsPage() {
     const csvContent = [
       ["Metric", "Category", "Value"],
       ["Total Respondents", "", data.totalRespondents.toString()],
-      ["Coffee Farmers", "", data.coffeeFarmers.toString()],
-      ["Tea Farmers", "", data.teaFarmers.toString()],
+      ["Coffee Respondents", "", data.coffeeRespondents.toString()],
+      ["Tea Respondents", "", data.teaRespondents.toString()],
       ...data.demographics.gender.map((item) => ["Gender", item.name, item.value.toString()]),
       ...data.demographics.education.map((item) => ["Education", item.name, item.value.toString()]),
       ...data.business.occupation.map((item) => ["Occupation", item.name, item.value.toString()]),
@@ -482,21 +478,21 @@ export default function AnalyticsPage() {
           </Card>
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Coffee Farmers</CardTitle>
+              <CardTitle className="text-sm font-medium">Coffee Respondents</CardTitle>
               <Briefcase className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{data?.coffeeFarmers || 0}</div>
+              <div className="text-2xl font-bold">{data?.coffeeRespondents || 0}</div>
               <p className="text-xs text-muted-foreground">Coffee value chain</p>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Tea Farmers</CardTitle>
+              <CardTitle className="text-sm font-medium">Tea Respondents</CardTitle>
               <Briefcase className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{data?.teaFarmers || 0}</div>
+              <div className="text-2xl font-bold">{data?.teaRespondents || 0}</div>
               <p className="text-xs text-muted-foreground">Tea value chain</p>
             </CardContent>
           </Card>

--- a/app/data-import/page.tsx
+++ b/app/data-import/page.tsx
@@ -101,16 +101,12 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
 
   const uniqueGenders = [...new Set(respondents.map((r) => r.gender).filter(Boolean))].sort()
 
-  const coffeeFarmersCount = respondents.filter(
-    (r) =>
-      r.value_chain_role?.toLowerCase().includes("farmer") &&
-      r.industry_involvement?.toLowerCase().includes("coffee"),
+  const coffeeRespondentsCount = respondents.filter((r) =>
+    r.industry_involvement?.toLowerCase().includes("coffee"),
   ).length
 
-  const teaFarmersCount = respondents.filter(
-    (r) =>
-      r.value_chain_role?.toLowerCase().includes("farmer") &&
-      r.industry_involvement?.toLowerCase().includes("tea"),
+  const teaRespondentsCount = respondents.filter((r) =>
+    r.industry_involvement?.toLowerCase().includes("tea"),
   ).length
 
   const exportData = () => {
@@ -249,8 +245,8 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
                   <span className="text-purple-600 font-bold">☕</span>
                 </div>
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-600">Coffee Farmers</p>
-                  <p className="text-2xl font-bold text-gray-900">{coffeeFarmersCount}</p>
+                  <p className="text-sm font-medium text-gray-600">Coffee Respondents</p>
+                  <p className="text-2xl font-bold text-gray-900">{coffeeRespondentsCount}</p>
                 </div>
               </div>
             </CardContent>
@@ -263,8 +259,8 @@ export default function DataImportPage({ embedded = false }: { embedded?: boolea
                   <span className="text-orange-600 font-bold">🍃</span>
                 </div>
                 <div className="ml-4">
-                  <p className="text-sm font-medium text-gray-600">Tea Farmers</p>
-                  <p className="text-2xl font-bold text-gray-900">{teaFarmersCount}</p>
+                  <p className="text-sm font-medium text-gray-600">Tea Respondents</p>
+                  <p className="text-2xl font-bold text-gray-900">{teaRespondentsCount}</p>
                 </div>
               </div>
             </CardContent>

--- a/app/respondents/page.tsx
+++ b/app/respondents/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
+import { normalize, toTitleCase } from "@/lib/utils"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"


### PR DESCRIPTION
## Summary
- count Coffee Respondents and Tea Respondents based on industry involvement across dashboard and analytics
- label coffee and tea sections as respondents instead of farmers
- import normalize and toTitleCase utilities on respondents page

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c00c88bd308333bd86b8361a4a668f